### PR TITLE
Added toggle to disable pimping of scala toolchain

### DIFF
--- a/polyglot-scala/src/test/scala/org/sonatype/maven/polyglot/scala/ScalaModelSpec.scala
+++ b/polyglot-scala/src/test/scala/org/sonatype/maven/polyglot/scala/ScalaModelSpec.scala
@@ -71,5 +71,25 @@ class ScalaModelSpec extends Specification {
       m.build.get.plugins(2).gav.artifactId must_== "maven-surefire-plugin"
       m.build.get.plugins(2).gav.version must_== Some("0")
     }
+
+    "configure a minimal project and pimp the scala settings" in {
+      val m = ScalaModel(
+          gav = "" % "maven-polyglot-scala",
+          pimpScalaToolchain = true
+      )
+
+      m.dependencies.size must be_>=(1)
+      m.build must_!= None
+    }
+
+    "configure a minimal project and do not pimp the scala settings" in {
+      val m = ScalaModel(
+          gav = "" % "maven-polyglot-scala",
+          pimpScalaToolchain = false
+      )
+
+      m.dependencies.size must_== 0
+      m.build.isEmpty must_== true
+    }
   }
 }


### PR DESCRIPTION
To disable automatic enrichment of the build model with Scala compiler and dependencies, one can set:

```scala
ScalaModel(
  gav = "g" % "a" % "1.0",
  // other stuff
  pimpScalaToolchain = false
)
```